### PR TITLE
Uplink costs

### DIFF
--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -31,8 +31,8 @@
 	name = "Random Items"
 	desc = "Buys you as many random items you can afford. Convenient packaging NOT included."
 
-/datum/uplink_item/item/badassery/random_many/cost(var/telecrystals)
-	return max(1, telecrystals)
+/datum/uplink_item/item/badassery/random_many/cost(obj/item/device/uplink/U)
+	return max(1, U.uses)
 
 /datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/device/uplink/U, var/loc)
 	var/list/bought_items = list()

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -21,7 +21,7 @@
 
 /datum/uplink_item/item/visible_weapons/g9mm
 	name = "Silenced 9mm"
-	item_cost = 8
+	item_cost = 7
 	path = /obj/item/weapon/storage/box/syndie_kit/g9mm
 
 /datum/uplink_item/item/visible_weapons/riggedlaser
@@ -31,21 +31,24 @@
 
 /datum/uplink_item/item/visible_weapons/revolver
 	name = "Revolver"
-	item_cost = 12
+	item_cost = 11
+	antag_costs = list(MODE_MERCENARY = 6)
 	path = /obj/item/weapon/gun/projectile/revolver
 
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
 /datum/uplink_item/item/visible_weapons/submachinegun
 	name = "Submachine Gun"
-	item_cost = 12
+	item_cost = 13
+	antag_costs = list(MODE_MERCENARY = 6)
 	path = /obj/item/weapon/gun/projectile/automatic/c20r
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
-	item_cost = 14
+	item_cost = 16
+	antag_costs = list(MODE_MERCENARY = 9)
 	path = /obj/item/weapon/gun/projectile/automatic/sts35
 
 /datum/uplink_item/item/visible_weapons/heavysniper
 	name = "Anti-materiel Rifle"
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 21
 	path = /obj/item/weapon/gun/projectile/heavysniper

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -27,5 +27,5 @@
 /datum/uplink_item/item/telecrystal/all
 	name = "Telecrystals - Empty Uplink"
 
-/datum/uplink_item/item/telecrystal/all/cost(var/telecrystals)
-	return max(1, telecrystals)
+/datum/uplink_item/item/telecrystal/all/cost(obj/item/device/uplink/U)
+	return max(1, U.uses)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -47,7 +47,7 @@ var/datum/uplink/uplink = new()
 	if(!can_buy(U))
 		return
 
-	var/cost = cost(U.uses)
+	var/cost = cost(U)
 
 	var/goods = get_goods(U, get_turf(user), user, extra_args)
 	if(!goods)
@@ -83,7 +83,7 @@ var/datum/uplink/uplink = new()
 			return 1
 	return 0
 
-/datum/uplink_item/proc/cost(var/telecrystals)
+/datum/uplink_item/proc/cost(obj/item/device/uplink/U)
 	return item_cost
 
 /datum/uplink_item/proc/description()

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -29,6 +29,7 @@ var/datum/uplink/uplink = new()
 	var/name
 	var/desc
 	var/item_cost = 0
+	var/list/antag_costs					// Allows specific antag roles to purchase at a different cost
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
 
@@ -38,6 +39,7 @@ var/datum/uplink/uplink = new()
 /datum/uplink_item/New()
 	..()
 	antag_roles = list()
+	antag_costs = list()
 
 /datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
 	var/extra_args = extra_args(user)
@@ -84,7 +86,13 @@ var/datum/uplink/uplink = new()
 	return 0
 
 /datum/uplink_item/proc/cost(obj/item/device/uplink/U)
-	return item_cost
+	. = item_cost
+
+	if(U.uplink_owner)
+		for(var/antag_role in antag_costs)
+			var/datum/antagonist/antag = all_antag_types[antag_role]
+			if(antag.is_antagonist(U.uplink_owner))
+				. = min(antag_costs[antag_role], . )
 
 /datum/uplink_item/proc/description()
 	return desc


### PR DESCRIPTION
They can now be specified for specific antag types.

Went ahead and adjusted a few costs, hope you don't mind. Ever since the c20r went automatic I felt the revolver kind of got shafted, so I adjusted it's price to make it a little more attractive.

Adjusted the PTR cost so that traitors can actually get ammo for it. I think it will be more fun for players this way, since you're blowing all of your TC on it anyways.

Also, other than compiling it I haven't tested anything, due to not having the BYOND windows client installed anymore.

You can include the above description in your PR if you choose to merge this.